### PR TITLE
[FIX] Убрал кривой вывод цветов в сообщении

### DIFF
--- a/DiscordBotConsole_module/src/main/java/pro/gravit/launchermodules/discordbot/DiscordBotListener.java
+++ b/DiscordBotConsole_module/src/main/java/pro/gravit/launchermodules/discordbot/DiscordBotListener.java
@@ -113,7 +113,7 @@ public class DiscordBotListener extends ListenerAdapter {
 
         public LogEventView(LogEvent event) {
             level = event.getLevel().toString();
-            message = event.getMessage().getFormattedMessage();
+            message = event.getMessage().getFormattedMessage().replaceAll("\u001B\\[[;\\d]*m", "");
             Throwable throwable = event.getMessage().getThrowable();
             if (throwable != null) {
                 exception = String.format("%s: %s", throwable.getClass().getName(), throwable.getMessage());


### PR DESCRIPTION
Из-за цветов вывод был такого формата:

```[INFO]  [92mgc  [96m[nothing] [m -  [93mnull [m 
[INFO]  [92mdebug  [96m[true/false] [true/false] [m -  [93mnull [m 
[INFO]  [92mrestart  [96m[nothing] [m -  [93mRestart LaunchServer [m

Применил регулярку вывод:

[INFO] gc [nothing] - null 
[INFO] debug [true/false] [true/false] - null 
[INFO] restart [nothing] - Restart LaunchServer