### PR TITLE
Add proper error handling/rethrowing in registration method in provider

### DIFF
--- a/FileAuthSystem_module/src/main/java/pro/gravit/launchermodules/fileauthsystem/providers/FileSystemAuthCoreProvider.java
+++ b/FileAuthSystem_module/src/main/java/pro/gravit/launchermodules/fileauthsystem/providers/FileSystemAuthCoreProvider.java
@@ -335,7 +335,7 @@ public class FileSystemAuthCoreProvider extends AuthCoreProvider implements Auth
         try {
             addUser(entity);
         } catch (RequestException e) {
-            return null;
+            throw new RuntimeException("Failed to add user", e);
         }
         return entity;
     }


### PR DESCRIPTION
Due to the fact that `registration` method semantics do not provide throws, it'll be better if exception was thrown when error is occurred, rather then returning `null` user
![image](https://github.com/GravitLauncher/LauncherModules/assets/16443338/73ebaf8f-bb1d-4110-88df-a929bfe9e606)
